### PR TITLE
use released stack; don't build our own

### DIFF
--- a/hlint-from-scratch.sh
+++ b/hlint-from-scratch.sh
@@ -101,7 +101,7 @@ locals="locals"
 everything="everything"
 
 # If there's a new release, let's have it.
-if true; then
+if false; then
   cd "$repo_dir/stack"
   git fetch origin && git merge origin/master
   stack --stack-yaml=stack-macos.yaml install


### PR DESCRIPTION
noting very bad interactions on one machine between a self built `stack` and `ghc-9.4.2` (unreasonable linker errors mostly). very mysterious. 